### PR TITLE
Send button value with form data when pressing a button of type 'submit'

### DIFF
--- a/jquery.popconfirm.js
+++ b/jquery.popconfirm.js
@@ -102,6 +102,8 @@
           // Get the form related to this button then store submiting in closure
           form = $(this).parents('form:first');
           arrayActions.push(function () {
+            hiddenInput = '<input type="hidden" name="' + self.attr('name') + '" value="' + self.val() + '" />';
+            form.append(hiddenInput);
             form.submit();
           });
         }


### PR DESCRIPTION
When not using jQuery to submit a form, if you press a button of type="submit", button's **value** attribute will be passed with other form elements. I think the same should happen when confirming form submission using PopConfirm. There are situations where forms include multiple buttons with same name but different values and logic of code which handles form data depends on which button is pressed.
