### PR TITLE
Work with jquery.unobtrusive-ajax.js

### DIFF
--- a/jquery.popconfirm.js
+++ b/jquery.popconfirm.js
@@ -92,7 +92,8 @@
         if (!self.data('remote') && self.attr('href')) {
           // Assume there is a href attribute to redirect to
           arrayActions.push(function () {
-            window.location.href = self.attr('href');
+            $(self).unbind("click");
+            $(self).click();
           });
         }
 


### PR DESCRIPTION
I had problems when I used popconfirm with ajax.unobstusive in the .NET MVC. This modification solved my problems and still it worked in another scenarios.